### PR TITLE
add entry about SlickLogin

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -444,7 +444,7 @@
     "dateClose": "2014-02-17",
     "dateOpen": "2013-07-13",
     "description": "SlickLogin was an Israeli start-up company which developed sound-based password alternatives, was acquired by Google and hasn't released anything since.",
-    "link": "https://en.wikipedia.org/wiki/SlickLogin"
+    "link": "https://en.wikipedia.org/wiki/SlickLogin",
     "name": "SlickLogin"
   }
 ]

--- a/graveyard.json
+++ b/graveyard.json
@@ -439,5 +439,12 @@
     "description": "Google Code Search was a free beta product from Google which debuted in Google Labs on October 5, 2006, allowing web users to search for open-source code on the Internet.",
     "link": "https://en.wikipedia.org/wiki/Google_Code_Search",
     "name": "Google Code Search"
+  },
+  {
+    "dateClose": "2014-02-17",
+    "dateOpen": "2013-07-13",
+    "description": "SlickLogin was an Israeli start-up company which developed sound-based password alternatives, was acquired by Google and hasn't released anything since.",
+    "link": "https://en.wikipedia.org/wiki/SlickLogin"
+    "name": "SlickLogin"
   }
 ]


### PR DESCRIPTION
Added an entry for SlickLogin which had a novel concept for "passwordless" logins using uniquely generated sound tokens. It was acquired by Google and they haven't released a commercial product since.