### PR TITLE
Add `Fabric`

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -464,7 +464,7 @@
   {
     "dateClose": "2019-06-01",
     "dateOpen": "2014-10-01",
-    "description": "Fabric is a platform that helps your mobile team build better apps, understand your users, and grow your business.",
+    "description": "Fabric was a platform that helped mobile teams build better apps, understand their users, and grow their business.",
     "link": "https://get.fabric.io/roadmap",
     "name": "Fabric Tango"
   }

--- a/graveyard.json
+++ b/graveyard.json
@@ -460,5 +460,12 @@
     "description": "Project Tango was an API for augmented reality apps that was killed and replaced by ARCore",
     "link": "https://en.wikipedia.org/wiki/Tango_(platform)",
     "name": "Project Tango"
+  },
+  {
+    "dateClose": "2019-06-01",
+    "dateOpen": "2014-10-01",
+    "description": "Fabric is a platform that helps your mobile team build better apps, understand your users, and grow your business.",
+    "link": "https://get.fabric.io/roadmap",
+    "name": "Fabric Tango"
   }
 ]


### PR DESCRIPTION
https://get.fabric.io/roadmap

> We are integrating the best of Fabric into Firebase to give you one powerful platform. We’ll support Fabric until mid 2019, but we encourage you to migrate to Firebase sooner so you can take advantage of the new tools we are building there.

https://venturebeat.com/2018/09/14/google-is-killing-fabric-in-mid-2019-pushes-developers-to-firebase/

