### PR TITLE
Fix `Fabric` name

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -466,6 +466,6 @@
     "dateOpen": "2014-10-01",
     "description": "Fabric was a platform that helped mobile teams build better apps, understand their users, and grow their business.",
     "link": "https://get.fabric.io/roadmap",
-    "name": "Fabric Tango"
+    "name": "Fabric"
   }
 ]


### PR DESCRIPTION
Copy pasta monster got me...

It's just "Fabric". "Tango" pulled from the entry above.

Opps!