### PR TITLE
Fix #100

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -705,5 +705,12 @@
     "description": "MyTracks was a GPS tracking application for Android which allowed users to track their path, speed, distance and elevation.",
     "link": "https://en.wikipedia.org/wiki/MyTracks",
     "name": "MyTracks"
+  },
+  {
+    "dateClose": "2016-02-18",
+    "dateOpen": "2013-06-01",
+    "description": "Pie was a work-centric groupchat website and app comparable to Slack. The Pie.co team was acqui-hired by google in 2016 and Pie is no longer available.",
+    "link": "https://www.pie.co",
+    "name": "Pie"
   }
 ]

--- a/graveyard.json
+++ b/graveyard.json
@@ -709,7 +709,7 @@
   {
     "dateClose": "2016-02-18",
     "dateOpen": "2013-06-01",
-    "description": "Pie was a work-centric groupchat website and app comparable to Slack. The Pie.co team was acqui-hired by google in 2016 and Pie is no longer available.",
+    "description": "Pie was a work-centric groupchat website and app comparable to Slack.",
     "link": "https://www.pie.co",
     "name": "Pie"
   }


### PR DESCRIPTION
For this product, some of the dates were difficult to find references for.

I had to do some background research and educated guesses.
- Based off the [pie.co website on wayback machine](https://web.archive.org/web/20150405075220/https://www.pie.co/about/), it was started in 2013, but no month or day were given, so i just did the "middle" of the year.
- There doesn't seem to be many articles talking about it's exact closing date, so I referenced [the blog post discussing it's acquisition](https://blog.google/around-the-globe/google-asia/building-engineering-team-in-singapore/). I imagine most users of the service were given a window to discontinue using it.
