### PR TITLE
refactor item.jsx to use formatDistance

### DIFF
--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -34,13 +34,9 @@ export default class Item extends Component {
 
   getYears() {
     const { dateClose, dateOpen } = this.props;
-    const diff = Math.floor(new Date(dateClose).getTime() - new Date(dateOpen).getTime());
-    const day = 1000 * 60 * 60 * 24;
-    const days = Math.floor(diff / day);
-    const months = Math.floor(days / 31);
-    const years = Math.round(months / 12, 1);
+    const duration = formatDistance(dateClose, dateOpen)
 
-    return years;
+    return (` It was ${duration} old.`)
   }
 
   isPast() {
@@ -108,7 +104,7 @@ export default class Item extends Component {
           <Description>
             {this.timePhrase()}
             {grave.description}
-            {` It was ${this.getYears()} years old.`}
+            {this.getYears()}
           </Description>
         </ContentContainer>
       </ListItem>


### PR DESCRIPTION
This PR addresses #112 by refactoring the `getYears()` function to use `formatDistance()` and return the duration message. 

how it looks now:
<img width="292" alt="screen shot 2018-10-21 at 16 52 56" src="https://user-images.githubusercontent.com/17116730/47272318-f2f4d900-d551-11e8-83cb-a7fa3705b234.png">
<img width="332" alt="screen shot 2018-10-21 at 16 54 43" src="https://user-images.githubusercontent.com/17116730/47272325-0a33c680-d552-11e8-945d-cabc1dbe9f35.png">
