### PR TITLE
Added Google One Pass

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -908,5 +908,12 @@
     "description": "Google Flu Vaccine Finder was a maps mash-up that showed nearby vaccination places across the United States.",
     "link": "https://googleblog.blogspot.com/2012/04/spring-cleaning-in-spring.html",
     "name": "Google Flu Vaccine Finder"
+  },
+  {
+    "dateClose": "2012-04-20",
+    "dateOpen": "2011-03-16",
+    "description": "Google One Pass was an online store developed by Google for media publishers looking to sell subscriptions to their content.",
+    "link": "https://en.wikipedia.org/wiki/Google_One_Pass",
+    "name": "Google One Pass"
   }
 ]


### PR DESCRIPTION
A service that lasted only a few months. It is not really clear why they took it down.

Funny to note that they kind of recycled the **One** suffix with the rebranding of Google _Drive_ to Google _One_...

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
