### PR TITLE
fix: Google Pack deprecation date

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -777,7 +777,7 @@
     "name": "Google Checkout"
   },
   {
-    "dateClose": "2011-09-31",
+    "dateClose": "2011-09-02",
     "dateOpen": "2006-01-06",
     "description": "Google Pack was a collection of software tools offered by Google to download in a single archive. It was announced at the 2006 Consumer Electronics Show, on January 6. Google Pack was only available for Windows XP, Windows Vista, and Windows 7.",
     "link": "https://en.wikipedia.org/wiki/Google_Pack",


### PR DESCRIPTION
Originally, the page was displaying an invalid date for Google Pack. And that's because 2011-09-31 doesn't exist :) so the function was returning `Invalid Date`

The actual date of the blog article when Google Pack was announced to be deprecated was in September 02
https://googleblog.blogspot.com/2011/09/fall-spring-clean.html