### PR TITLE
fix(graveyard): BumpTop spacing fix

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -767,7 +767,7 @@
     "dateOpen": "2008-04-13",
     "description": "BumpTop was a skeuomorphic desktop environment app that simulates the normal behavior and physical properties of a real-world desk and enhances it with automatic tools to organize its contents.",
     "link": "https://github.com/BumpTop/BumpTop",
-    "name": "Bump Top"
+    "name": "BumpTop"
   },
   {
     "dateClose": "2013-11-20",


### PR DESCRIPTION
Minor fix, this one, but the spacing was not represented correctly for BumpTop.

https://en.wikipedia.org/wiki/BumpTop