### PR TITLE
test: Add moment library for date validation

### DIFF
--- a/graveyard.test.js
+++ b/graveyard.test.js
@@ -1,8 +1,9 @@
 const data = require('./graveyard.json');
+const moment = require('moment');
 
 
 describe('graveyard', () => {
-  it('graveyard', () => {
+  it('objects should be valid', () => {
     data.forEach((product) => {
       // All data is present for each product
       expect(product.dateClose).not.toBeNull();
@@ -32,9 +33,11 @@ describe('graveyard', () => {
       expect(product.dateOpen.split('-')[2]).toHaveLength(2);
 
       // Dates are Chronologically Correct
-      const dateClose = new Date(product.dateClose).getTime();
-      const dateOpen = new Date(product.dateOpen).getTime();
-      expect(dateOpen).toBeLessThanOrEqual(dateClose);
+      const dateClose = moment(product.dateClose);
+      const dateOpen = moment(product.dateOpen);
+      expect(dateClose.isValid()).toBe(true);
+      expect(dateOpen.isValid()).toBe(true);
+      expect(dateClose.isAfter(dateOpen)).toBe(true);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.11.1",
     "jest": "^23.6.0",
+    "moment": "^2.22.2",
     "node-sass": "^4.9.3",
     "react-hot-loader": "^4.3.3",
     "sass-loader": "^7.1.0",


### PR DESCRIPTION
There needs to be a standard way to validate date, and different browsers have differing implementations.
```
Firefox Quantum 63.0 (64-bit)
  > new Date("2011-09-31") 
  > Invalid Date

Chrome Version 70.0.3538.77 (Official Build) (64-bit)
  > new Date("2011-09-31")
  > Fri Sep 30 2011 20:00:00 GMT-0400 (Eastern Daylight Time)
```

In both cases, the date is either incorrect, or misrepresented. 

Enter, the moment library. 

It's chunky, yes, but offers a standard implementation for validating date. It's also only needed as a developer dependency.