### PR TITLE
Added Google Allo in graveyard.json

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2,7 +2,7 @@
   {
     "dateClose": "2018-04-19",
     "dateOpen": "2016-09-21",
-    "description": "Google Allo is an instant messaging mobile app by Google. It will be rebranded as Google Chat."
+    "description": "Google Allo is an instant messaging mobile app by Google. It will be rebranded as Google Chat.",
     "link": "https://en.wikipedia.org/wiki/Google_Allo",
     "name": "Google Allo"
   },

--- a/graveyard.json
+++ b/graveyard.json
@@ -1,4 +1,11 @@
-[
+﻿[
+  {
+    "dateClose": "2018-04-19",
+    "dateOpen": "2016-09-21",
+    "description": "Google Allo is an instant messaging mobile app by Google. It will be rebranded as Google Chat."
+    "link": "https://en.wikipedia.org/wiki/Google_Allo",
+    "name": "Google Allo"
+  },
   {
     "dateClose": "2015-04-25",
     "dateOpen": "2013-07-26",


### PR DESCRIPTION
Added Google Allo as a product that is being killed off by Google. Google announced in April of 2018 that it will pause all development of Google Allo, completely rebranding it as Google Chat. 

#183 