### PR TITLE
Google+ is not dead yet, but scheduled for august 2019

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -427,7 +427,7 @@
     "name": "Google PowerMeter"
   },
   {
-    "dateClose": "2018-10-08",
+    "dateClose": "2019-08-31",
     "dateOpen": "2011-06-28",
     "description": "Google+ was an Internet-based social network.",
     "link": "https://en.wikipedia.org/wiki/Google%2B",


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Google%2B#Shutdown_of_consumer_version