### PR TITLE
Add Chromecast Audio to the graveyard

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2019-01-11",
+    "dateOpen": "2015-09-29",
+    "description": "A simple device that allows you to stream audio to your speakers.",
+    "link": "https://en.wikipedia.org/wiki/Chromecast#Chromecast_Audio",
+    "name": "Chromecast Audio",
+    "type": "hardware"
+  },
+  {
     "dateClose": "2019-03-31",
     "dateOpen": "2016-09-21",
     "description": "Google Allo is an instant messaging mobile app by Google. It will be rebranded as Google Chat.",


### PR DESCRIPTION
Sources: 
https://9to5google.com/2019/01/11/google-discontinued-chromecast-audio/
https://store.google.com/product/chromecast_audio

Note: I'm unsure about the description, please advice if you don't like it.

