### PR TITLE
Improve product name of Google Play Edition phones

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -522,9 +522,9 @@
   {
     "dateClose": "2015-01-01",
     "dateOpen": "2014-05-01",
-    "description": "Google Play was an edition of an Android phone that Google sold.",
+    "description": "Google Play Edition was a type of an Android smartphones that Google sold.",
     "link": "https://arstechnica.com/gadgets/2015/01/dont-cry-for-the-google-play-edition-program-it-was-already-dead/",
-    "name": "Google Play",
+    "name": "Google Play Edition",
     "type": "hardware"
   },
   {


### PR DESCRIPTION
- Modified "Google Play" to "Google Play Edition" to avoid confusion.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
