### PR TITLE
Remove Sky Map from Graveyard. Close #316

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1136,14 +1136,6 @@
     "type": "service"
   },
   {
-    "dateClose": "2012-01-20",
-    "dateOpen": "2009-05-12",
-    "description": "Google Sky Map was an augmented reality star mapping application for Android devices.",
-    "link": "https://en.wikipedia.org/wiki/Sky_Map",
-    "name": "Google Sky Map",
-    "type": "app"
-  },
-  {
     "dateClose": "2011-12-20",
     "dateOpen": "2007-07-01",
     "description": "Apture was a service that allowed publishers and bloggers to link and incorporate multimedia into a dynamic layer above their pages.",


### PR DESCRIPTION
Removed the Sky Map entry from the graveyard since issue #316 has been open for two weeks.

Sorry for PR #360; still new to them and didn't realize GitHub appends new commits to the same PR if the branches match. This new PR follows better PR etiquette.
