### PR TITLE
Google Data Saver Extension for Chrome 

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1246,5 +1246,13 @@
     "link": "http://google-tvads.blogspot.com/2009/02/google-exits-radio-but-will-explore.html",
     "name": "Google Audio Ads",
     "type": "service"
+  },
+  {
+    "dateClose": "2019-04-23",
+    "dateOpen": "2015-03-23",
+    "description": "Data Saver extension for Chrome browser allowed it to send webpages through Google servers which compressed them saving bandwidth charges.",
+    "link": "https://blog.chromium.org/2019/04/data-saver-is-now-lite-mode.html",
+    "name": "Data Saver Extension for Chrome",
+    "type": "service"
   }
 ]

--- a/graveyard.json
+++ b/graveyard.json
@@ -1248,6 +1248,38 @@
     "type": "service"
   },
   {
+    "dateClose": "2015-01-14",
+    "dateOpen": "2010-12-06",
+    "description": "Word Lens translated text in real time on images by using the viewfinder of a device's camera without the need of an internet connection; The technology was rolled into Google Translate.",
+    "link": "https://en.wikipedia.org/wiki/Word_Lens",
+    "name": "Word Lens",
+    "type": "app"
+  },
+  {
+    "dateClose": "2019-05-29",
+    "dateOpen": "2012-06-27",
+    "description": "Google Cloud Messaging (GCM) was a notification service that enabled developers to send messages between servers and client apps running on Android or Chrome.",
+    "link": "https://en.wikipedia.org/wiki/Google_Cloud_Messaging",
+    "name": "Google Cloud Messaging (GCM)",
+    "type": "service"
+  },
+  {
+    "dateClose": "2019-10-31",
+    "dateOpen": "2013-03-15",
+    "description": "Google Hangouts was a communication platform which included messages, video chat, and VOIP features. Execution date is tentative.",
+    "link": "https://arstechnica.com/gadgets/2019/01/the-great-google-hangouts-shutdown-begins-october-2019/",
+    "name": "Google Hangouts",
+    "type": "service"
+  },
+  {
+    "dateClose": "2019-01-15",
+    "dateOpen": "2013-03-19",
+    "description": "Google Realtime API provided ways to synchronise resources between devices. It operated on files stored on Google Drive.",
+    "link":"https://developers.google.com/realtime/overview",
+    "name": "Google Realtime API",
+    "type": "service"
+  },
+  {
     "dateClose": "2019-04-23",
     "dateOpen": "2015-03-23",
     "description": "Data Saver extension for Chrome browser allowed it to send webpages through Google servers which compressed them saving bandwidth charges.",


### PR DESCRIPTION
It is getting deprecated with v74 of the Chrome browser.
https://blog.chromium.org/2019/04/data-saver-is-now-lite-mode.html