### PR TITLE
Google killed Pixel Slate (graveyard.json update)

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2019-06-20",
+    "dateOpen": "2018-10-09",
+    "description": "Pixel Slate was a tablet running Chrome OS.",
+    "link": "https://9to5google.com/2019/06/20/google-tablet-abandoned-development/",
+    "name": "Pixel Slate",
+    "type": "hardware"
+  },
+  {
     "dateClose": "2017-09-20",
     "dateOpen": "2010-06-15",
     "description": "YouTube Video Editor was a web-based tool for editing, merging, and adding special effects to video content.",

--- a/graveyard.json
+++ b/graveyard.json
@@ -3,7 +3,7 @@
     "dateClose": "2019-06-20",
     "dateOpen": "2018-10-09",
     "description": "Pixel Slate was a tablet running Chrome OS.",
-    "link": "https://9to5google.com/2019/06/20/google-tablet-abandoned-development/",
+    "link": "https://en.wikipedia.org/wiki/Pixel_Slate",
     "name": "Pixel Slate",
     "type": "hardware"
   },

--- a/graveyard.json
+++ b/graveyard.json
@@ -2,7 +2,7 @@
   {
     "dateClose": "2019-06-20",
     "dateOpen": "2018-10-09",
-    "description": "Pixel Slate was a tablet running Chrome OS.",
+    "description": "Pixel Slate was a line of tablet devices that ran on the Chrome OS operating system.",
     "link": "https://en.wikipedia.org/wiki/Pixel_Slate",
     "name": "Pixel Slate",
     "type": "hardware"


### PR DESCRIPTION
I didn't use the link to wikipedia because the page it's not yet updated

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
