### PR TITLE
Update Google Hangouts dateClose.

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1288,7 +1288,7 @@
     "type": "service"
   },
   {
-    "dateClose": "2019-10-31",
+    "dateClose": "2020-12-31",
     "dateOpen": "2013-03-15",
     "description": "Google Hangouts was a communication platform which included messages, video chat, and VOIP features. Execution date is tentative.",
     "link": "https://arstechnica.com/gadgets/2019/01/the-great-google-hangouts-shutdown-begins-october-2019/",


### PR DESCRIPTION
Per 9to5Google:

https://9to5google.com/2019/08/21/google-delays-hangouts-death/

Google's Official Death March (Timeline):

https://support.google.com/a/answer/9197126

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
