### PR TITLE
Youtube messages

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1430,5 +1430,13 @@
     "link": "https://support.google.com/a/answer/7039472",
     "name": "G Suite Training",
     "type": "service"
+  },
+  {
+    "dateClose": "2019-09-18",
+    "dateOpen": "2017-08-07",
+    "description": "Youtube Mesagging was and in-app feature that would allow YouTube users to private-send their friends videos and chat within a dedicated tab in the YouTube mobile app",
+    "link": "https://support.google.com/youtube/answer/6401227",
+    "name": "Youtube Mesagging",
+    "type": "service"
   }
 ]

--- a/graveyard.json
+++ b/graveyard.json
@@ -1434,9 +1434,9 @@
   {
     "dateClose": "2019-09-18",
     "dateOpen": "2017-08-07",
-    "description": "Youtube Mesagging was and in-app feature that would allow YouTube users to private-send their friends videos and chat within a dedicated tab in the YouTube mobile app",
+    "description": "Youtube Messages was and in-app feature that would allow YouTube users to private-send their friends videos and chat within a dedicated tab in the YouTube mobile app",
     "link": "https://support.google.com/youtube/answer/6401227",
-    "name": "Youtube Mesagging",
+    "name": "Youtube Messages",
     "type": "service"
   }
 ]


### PR DESCRIPTION
Here is the source from google:
https://support.google.com/youtube/answer/6401227

another refereces used for dates:
https://techcrunch.com/2019/08/21/youtube-is-closing-its-private-messages-feature-and-many-kids-are-outraged/
https://techcrunch.com/2017/08/07/youtube-roll-out-in-app-video-sharing-and-messaging-to-users-worldwide/
