### PR TITLE
escape search term before regex compilation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,7 +49,7 @@ export default class App extends Component {
 
   search() {
     const { fullList, activeFilter, term } = this.state;
-    const regexp = new RegExp(term.toLowerCase(), 'i');
+    const regexp = new RegExp(term.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
     // If a filter is active, only search through those results
     const list = activeFilter
       ? fullList.filter(el => el.type === activeFilter)


### PR DESCRIPTION
escape search term before regex compilation to prevent `Invalid regular expression` exception when entering invalid regex strings into search box. Ex: `*` breaks search box.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
