### PR TITLE
Fixed a missing word in the Noop description

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1114,7 +1114,7 @@
   {
     "dateClose": "2011-12-31",
     "dateOpen": "2009-01-01",
-    "description": "Noop was a project by Google engineers Alex Eagle and Christian Gruber aiming to develop a new programming that attempted to blend the best features of 'old' and 'new' languages and best-practices.",
+    "description": "Noop was a project by Google engineers Alex Eagle and Christian Gruber aiming to develop a new programming language that attempted to blend the best features of 'old' and 'new' languages and best-practices.",
     "link": "https://en.wikipedia.org/wiki/Noop",
     "name": "Noop Programming Language",
     "type": "service"


### PR DESCRIPTION
Fixed a missing word in the Noop description

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
