### PR TITLE
Update graveyard.json

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1550,5 +1550,13 @@
     "link": "https://googleblog.blogspot.com/2012/04/spring-cleaning-in-spring.html",
     "name": "Google Related",
     "type": "service"
+  },
+  {
+    "dateClose": "2020-01-31",
+    "dateOpen": "2012-03-05",
+    "description": "Bitium was a single sign-on and identity management service for cloud-based applications",
+    "link": "https://en.wikipedia.org/wiki/Bitium",
+    "name": "Bitium",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
"Bitium is turning down on January 31, 2020" per https://www.bitium.com/, after being bought by Google in 2017.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
