### PR TITLE
Add Google Play Music to graveyard.json

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2020-12-31",
+    "dateOpen": "2011-11-16",
+    "description": "Google Play Music was a music and podcast streaming service, and online music locker.",
+    "link": "https://youtube.googleblog.com/2020/05/youtube-music-transfer-google-play-music-library.html",
+    "name": "Google Play Music",
+    "type": "service"
+  },
+  {
     "dateClose": "2020-05-12",
     "dateOpen": "2019-06-10",
     "description": "App used to find group activities with others who share your interests on Shoelace",


### PR DESCRIPTION
They haven't specifically mentioned an end-of-service date, but it's mentioned to be 'before the end of the year' in at least one source:

- https://www.forbes.com/sites/barrycollins/2020/05/13/google-play-music-is-dying-dont-let-it-take-your-mp3-collection-with-it/#728797b145c2