### PR TITLE
Update AngularJS to mention 1.x

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1586,9 +1586,9 @@
   {
     "dateClose": "2021-06-30",
     "dateOpen": "2010-10-20",
-    "description": "AngularJS was a JavaScript open-source front-end web framework based on MVC pattern using a dependency injection technique.",
+    "description": "AngularJS 1.x was a JavaScript open-source front-end web framework based on MVC pattern using a dependency injection technique.",
     "link": "https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c",
-    "name": "AngularJS",
+    "name": "AngularJS 1.x",
     "type": "service"
   },
   {


### PR DESCRIPTION
Seeing the Angular entry, it seemed to me at first Angular as a whole (AngularJS and Angular [2+]) was deprecated.
Digging deeper I found of course thats not the case.
So, to make the the entry more precise I'm attempting another PR like #683.

The `1.x` is kinda redundant to AngularJS, but for me makes it instantly clearer.

If your opinion remains the same as in #683, feel free to close.