### PR TITLE
Link to the proper Google Currents Wikipedia

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1059,7 +1059,7 @@
     "dateClose": "2013-11-20",
     "dateOpen": "2011-12-08",
     "description": "Google Currents was a social magazine app by google, which was replaced by Google Play Newsstand.",
-    "link": "https://en.wikipedia.org/wiki/Google_Currents",
+    "link": "https://en.wikipedia.org/wiki/Google_Currents_(2011-2013)",
     "name": "Google Currents",
     "type": "app"
   },


### PR DESCRIPTION
Although there is currently a link at the existing Google Currents page, most of the content targets the unrelated product of the same name.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
