### PR TITLE
Google cloud print

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2,7 +2,7 @@
   {
     "dateClose": "2020-12-31",
     "dateOpen": "2010-04-16",
-    "description": " Google service that lets users print from any Cloud Print-aware application (web, desktop, mobile) on any device in the network cloud to any printer with native support for connecting to cloud print services",
+    "description": "Google service that lets users print from any Cloud Print-aware application (web, desktop, mobile) on any device in the network cloud to any printer with native support for connecting to cloud print services.",
     "link": "https://en.wikipedia.org/wiki/Google_Cloud_Print",
     "name": "Google Cloud Print",
     "type": "Service"

--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2020-12-31",
+    "dateOpen": "2010-04-16",
+    "description": " Google service that lets users print from any Cloud Print-aware application (web, desktop, mobile) on any device in the network cloud to any printer with native support for connecting to cloud print services",
+    "link": "https://en.wikipedia.org/wiki/Google_Cloud_Print",
+    "name": "Google Cloud Print",
+    "type": "Service"
+  },
+  {
     "dateClose": "2020-08-31",
     "dateOpen": "2019-02-05",
     "description": "Whenever you signed in to a site, Password Checkup triggered a warning if the username and password you used were one of over 4 billion credentials that Google knew to be unsafe.",


### PR DESCRIPTION
<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
Cloud Print Service about to be deprecated from December 2020.