### PR TITLE
Add Sceneform SDK for Android

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1766,5 +1766,13 @@
     "link": "https://9to5google.com/2020/12/14/google-home-max-discontinued/",
     "name": "Google Home Max",
     "type": "hardware"
+  },
+  {
+    "dateClose": "2020-07-30",
+    "dateOpen": "2018-05-08",
+    "description": "Sceneform SDK for Android was a library and toolset for building AR scenes.",
+    "link": "https://stackoverflow.com/questions/62453399/google-sceneform-is-it-deprecated-any-replacement",
+    "name": "Sceneform SDK for Android",
+    "type": "app"
   }
 ]


### PR DESCRIPTION
Unclear what best to use as the link for more information. Google has not made the "killed" status clear.  The stackoverflow link includes links and information to other sources.

Supporting Information
- https://developers.google.com/sceneform
- https://github.com/google-ar/sceneform-android-sdk
- https://stackoverflow.com/questions/62453399/google-sceneform-is-it-deprecated-any-replacement
- https://www.reddit.com/r/androiddev/comments/glduwe/is_sceneform_dead/

Date Open
- https://github.com/google-ar/sceneform-android-sdk/releases/tag/v1.0.0
- https://venturebeat.com/2018/05/08/google-debuts-arcore-1-2-with-sceneform-augmented-images-android-and-ios-cloud-anchors/

Date Closed (published a final v1.17.1 release)
- https://mvnrepository.com/artifact/com.google.ar.sceneform/sceneform-base/1.17.1
- Alternatively, 2020-05-15, which is date deprecation/archival was announced:
	- https://github.com/google-ar/sceneform-android-sdk/commit/26256a02d6f116a1a45f69647e595aa596a1341a