### PR TITLE
Add Timely Alarm Clock

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1816,7 +1816,7 @@
     "type": "app"
   },
   {
-    "dateClose": "2019-09-03",
+    "dateClose": "2021-05-31",
     "dateOpen": "2013-08-18",
     "description": "Timely Alarm Clock was an Android application providing alarm, stopwatch and timer functionality with synchronisation across devices.",
     "link": "http://www.bitspin.ch/google",

--- a/graveyard.json
+++ b/graveyard.json
@@ -1784,6 +1784,14 @@
     "type": "app"
   },
   {
+    "dateClose": "2019-09-03",
+    "dateOpen": "2013-08-18",
+    "description": "Timely Alarm Clock was an Android application providing alarm, stopwatch and timer functionality with synchronisation across devices.",
+    "link": "http://www.bitspin.ch/google",
+    "name": "Timely",
+    "type": "app"
+  },
+  {
     "dateClose": "2021-01-22",
     "dateOpen": "2014-06-14",
     "description": "Loon was a service to provide internet access via an array of high-altitude balloons hovering in the Earth's stratsophere",


### PR DESCRIPTION
Developed by Bitspin, this Android application was never significantly updated after Google acquired them in 2014-01. Last updated on 2018-08-09, it does not work properly with Android 10 because it can no longer appear on top of the lock screen and its stopwatch/timer notification updates get frozen.

https://play.google.com/store/apps/details?id=ch.bitspin.timely

End date is the release date of Android 10.