### PR TITLE
Change de to en for Wikipedia Entry

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1723,7 +1723,7 @@
     "dateClose": "2021-06-30",
     "dateOpen": "2015-08-01",
     "description": "Expeditions is a program for providing virtual reality experiences to school classrooms through Google Cardboard viewers, allowing educators to take their students on virtual field trips.",
-    "link": "https://de.wikipedia.org/wiki/Google_Expeditions",
+    "link": "https://en.wikipedia.org/wiki/Google_Expeditions",
     "name": "Expeditions",
     "type": "app"
   },


### PR DESCRIPTION
Updated Google Expeditions to use the english version of wikipedia rather than the German. As much as I love German it is an english speaking site so I would have thought the `link` should be English as well.