### PR TITLE
Add Android Things' death date

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2022-01-05",
+    "dateOpen": "2015-05-28",
+    "description": "An Android-based embedded operating system (originally named Brillo) aimed to run on Internet of Things (IoT) devices",
+    "link": "https://android-developers.googleblog.com/2019/02/an-update-on-android-things.html",
+    "name": "Android Things",
+    "type": "service"
+  },
+  {
     "dateClose": "2020-06-24",
     "dateOpen": "2018-09-01",
     "description": "Pigeon Transit was a transit app that used croudsourced information about delays, crowded trains, escalator outages, live entertainment, dirty or unsafe conditions.",


### PR DESCRIPTION
Related to #296 and #628. They've been closed due to being "stale" so I'm getting this entry added.

About date choices:

As is written on Google's own [FAQ page](https://developer.android.com/things/faq), they're taking the whole thing down on 2022-01-05, so I chose this specific date as the final moment for Android Things.

Brillo (announced 2015-05-28) might be considered as its predecessor (and Android Things' codename is still `Brillo`, [per Wikipedia](https://en.wikipedia.org/wiki/Android_Things)) so I chose Brillo's launch date as `dateOpen` instead of 2016-12-13.