### PR TITLE
Use the 2022 date for Google Chrome Apps shutdown

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -544,7 +544,7 @@
     "type": "service"
   },
   {
-    "dateClose": "2021-06-30",
+    "dateClose": "2022-06-30",
     "dateOpen": "2010-12-06",
     "description": "Google Chrome Apps were hosted or packaged web applications that ran on the Google Chrome browser.",
     "link": "https://en.wikipedia.org/wiki/Google_Chrome_App",


### PR DESCRIPTION
Based on the [Chromium blog](https://blog.chromium.org/2020/08/changes-to-chrome-app-support-timeline.html), I would think that the 2022 date applies here. The previous 2021 date is when running Chrome Apps on Windows, macOS, or Linux will require a policy being set. The 2022 date is the final end of support for Chrome Apps.