### PR TITLE
Add Tilt Brush

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2022-01-26",
+    "dateOpen": "2016-04-05",
+    "description": "Tilt Brush was a room-scale 3D-painting virtual-reality application available from Google, originally developed by Skillman & Hackett. .",
+    "link": "https://www.tiltbrush.com/",
+    "name": "Tilt Brush",
+    "type": "app"
+  },
+  {
     "dateClose": "2022-01-05",
     "dateOpen": "2015-05-28",
     "description": "Android Things was an Android-based embedded operating system (originally named Brillo) aimed to run on Internet of Things (IoT) devices.",

--- a/graveyard.json
+++ b/graveyard.json
@@ -1,6 +1,6 @@
 [
   {
-    "dateClose": "2022-01-26",
+    "dateClose": "2021-01-26",
     "dateOpen": "2016-04-05",
     "description": "Tilt Brush was a room-scale 3D-painting virtual-reality application available from Google, originally developed by Skillman & Hackett. .",
     "link": "https://www.tiltbrush.com/",


### PR DESCRIPTION
Google haven't out and out said it's dead, but it's been strongly implied by two sources:

[1] https://opensource.googleblog.com/2021/01/the-future-of-tilt-brush.html states that

> Please note that it is not an actively developed product, and no pull requests will be accepted

[2] https://github.com/googlevr/tilt-brush

The repo is up but archived.

--

I don't know if KBG allows products that are being sold but not developed to be considered "killed". Sounds like there is no dev time going into the project at any rate, so I leave this to the maintainers discretion.
