### PR TITLE
Google play movies and tv

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2021-06-15",
+    "dateOpen": "2011-05-10",
+    "description": "Google Play Movies & TV, originally Google TV, was an app used to view purchased and rented media and was ultimately replaced with YouTube.",
+    "link": "https://en.wikipedia.org/wiki/Google_TV",
+    "name": "Google Play Movies & TV",
+    "type": "app"
+  },
+  {
     "dateClose": "2021-03-31",
     "dateOpen": "2010-01-01",
     "description": "(also known as Google Short Links) was a URL shortening service. It also supported custom domain for customers of Google Workspace (formerly G Suite (formerly Google Apps)).",

--- a/graveyard.json
+++ b/graveyard.json
@@ -1,7 +1,7 @@
 [
   {
-    "dateClose": "2021-06-15",
-    "dateOpen": "2011-05-10",
+    "dateClose": "2011-05-10",
+    "dateOpen": "2021-06-15",
     "description": "Google Play Movies & TV, originally Google TV, was an app used to view purchased and rented media and was ultimately replaced with YouTube.",
     "link": "https://en.wikipedia.org/wiki/Google_TV",
     "name": "Google Play Movies & TV",


### PR DESCRIPTION
Updated with correct dateOpen and dateClose.

Until Wikipedia gets updated, here's the source for dateClose:
https://support.google.com/googleplay/thread/102498448?hl=en
