### PR TITLE
Disambiguate AngularJS from the modern Angular.

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1754,7 +1754,7 @@
   {
     "dateClose": "2021-12-31",
     "dateOpen": "2010-10-20",
-    "description": "AngularJS was a JavaScript open-source front-end web framework based on MVC pattern using a dependency injection technique.",
+    "description": "AngularJS (not to be confused with its successor, Angular) was a JavaScript open-source front-end web framework based on MVC pattern using a dependency injection technique.",
     "link": "https://blog.angular.io/stable-angularjs-and-long-term-support-7e077635ee9c",
     "name": "AngularJS",
     "type": "service"


### PR DESCRIPTION
People might confuse the legacy AngularJS with the modern Angular framework; I encountered such confusion just now.