### PR TITLE
Clarify that Encrypted Search is still available.

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -498,7 +498,7 @@
   {
     "dateClose": "2018-04-30",
     "dateOpen": "2010-05-31",
-    "description": "Encrypted Search provided users with anonymous internet searching.",
+    "description": "Encrypted Search provided users with anonymous internet searching. In its place, Google uses HTTPS encryption by default for everyone.",
     "link": "https://en.wikipedia.org/wiki/Google_Search#Dedicated_encrypted_search_page",
     "name": "Encrypted Search",
     "type": "service"


### PR DESCRIPTION
Google did not discontinue Encrypted Search, it merged it with its main product as HTTPS became the norm.

I would argue that this entry is misleading and should be removed, but a clarification would have been less controversial.