### PR TITLE
Add G Suite legacy free edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To add a product, gather the following information:
 - Launch Date (`dateOpen`)
 - Discontinued Date (`dateClose`)
 - Description (`description`)
-- Link (`link`) - Relevant link to the source
+- Link (`link`) - Relevant link to the source (Please try to avoid Google Support articles as they tend to be taken down quickly - news articles work better.)
 - Type (`type`) - one of App, Service or Hardware
 
 If you are not familiar with or do not want to use `git`, submit a [new issue](https://github.com/codyogden/killedbygoogle/issues/new?template=add-an-obituary.md) requesting the change. If you are already familiar with `git`, follow these steps:

--- a/graveyard.json
+++ b/graveyard.json
@@ -1966,5 +1966,13 @@
     "link": "https://support.google.com/materialgallery/answer/11044972?hl=en&ref_topic=11045865",
     "name": "Material Gallery",
     "type": "service"
+  },
+  {
+    "dateClose": "2022-05-01",
+    "dateOpen": "2006-08-28",
+    "description": "G Suite legacy free edition was a free tier offering of Google Workspace (formerly G Suite (formerly Google Apps)), with maximum user limits of 10-50 users depending on when the account was created.",
+    "link": "https://support.google.com/a/answer/2855120",
+    "name": "G Suite legacy free edition",
+    "type": "service"
   }
 ]

--- a/graveyard.json
+++ b/graveyard.json
@@ -1971,7 +1971,7 @@
     "dateClose": "2022-05-01",
     "dateOpen": "2006-08-28",
     "description": "G Suite legacy free edition was a free tier offering of Google Workspace (formerly G Suite (formerly Google Apps)), with maximum user limits of 10-50 users depending on when the account was created.",
-    "link": "https://support.google.com/a/answer/2855120",
+    "link": "https://9to5google.com/2022/01/19/g-suite-legacy-free-edition/",
     "name": "G Suite legacy free edition",
     "type": "service"
   }


### PR DESCRIPTION
Hey Cody!

Long time follower... saw this sad news today. :( 

I wasn't quite sure whether to use 2022-05-01, or 2022-07-01 for the `closeDate`, since both dates are referenced in the linked article from Google. I went with the May date for now... happy to change it to July if you think that's more appropriate.

Cheers,
Ty