### PR TITLE
Add chrome lite mode

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2116,7 +2116,7 @@
     "dateOpen": "2014-01-15",
     "dateClose": "2022-03-29",
     "link": "https://www.androidpolice.com/google-is-retiring-chromes-data-saving-lite-mode-next-month-saying-its-no-longer-necessary/",
-    "description": "Chrome Lite Mode was a data saving feature that compressed websites server-side.",
+    "description": "Chrome Lite Mode was a feature that compressed websites using Google servers and saved data on mobile devices.",
     "type": "service"
   }
 ]

--- a/graveyard.json
+++ b/graveyard.json
@@ -2110,5 +2110,13 @@
     "link": "https://www.theverge.com/2022/2/10/22928042/google-plus-replacement-wind-down-currents-spaces",
     "description": "Google Currents was service that provided social media features similar to Google+ for Google Workspace customers.",
     "type": "service"
+  },
+  {
+    "name": "Chrome Lite Mode",
+    "dateOpen": "2014-01-15",
+    "dateClose": "2022-03-29",
+    "link": "https://www.androidpolice.com/google-is-retiring-chromes-data-saving-lite-mode-next-month-saying-its-no-longer-necessary/",
+    "description": "Chrome Lite Mode was a data saving feature that compressed websites server-side.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Introduced January 15th 2014 https://www.zdnet.com/article/google-proxy-used-for-chromes-mobile-data-compression/ and will be closed on March 29 2022 https://www.theverge.com/2022/2/23/22947441/google-lite-mode-data-saver-chrome-android-discontinued

Closes https://github.com/codyogden/killedbygoogle/issues/1168