### PR TITLE
Fix close date for Google Assistant Snapshot

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2122,7 +2122,7 @@
   {
     "name": "Google Assistant Snapshot",
     "dateOpen": "2018-07-17",
-    "dateClose": "2022-03-03",
+    "dateClose": "2022-04-13",
     "link": "https://www.droid-life.com/2022/03/03/googles-assistant-snapshot-is-going-away/",
     "description": "Google Assistant Snapshot was the successor to Google Now that provided predictive cards with information and daily updates in the Google app for Android and iOS.",
     "type": "service"


### PR DESCRIPTION
The old date was when Google announced the service was being shut down. The new date is when it was actually removed 

https://9to5google.com/2022/04/13/google-assistant-snapshot-appears-to-finally-sadly-be-gone-for-good/
https://www.androidpolice.com/google-is-killing-snapshot-the-now-replacement-that-never-took-off/#update-2022-04-14-14-13-est-by-will-sattelberg