### PR TITLE
add google stadia

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2023-01-18",
+    "dateOpen": "2019-11-19",
+    "description": "Stadia was a cloud gaming service developed and operated by Google. It is accessible through Chromecast Ultra and Android TV devices",
+    "link": "https://stadia.google.com/",
+    "name": "Google Stadia",
+    "type": "service"
+  },
+  {
     "dateClose": "2022-06-21",
     "dateOpen": "2019-11-04",
     "description": "Android Auto for phone screens was an app that allowed the screen of the phone to be used as an Android Auto interface while driving, intended for vehicles that did not have a compatible screen built in.",


### PR DESCRIPTION
<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->

https://www.theverge.com/2022/9/29/23378713/google-stadia-shutting-down-game-streaming-january-2023

> The service will remain live for players until January 18th, 2023. Google will be refunding all Stadia hardware purchased through the Google Store as well as all the games and add-on content purchased from the Stadia store. Google expects those refunds will be completed in mid-January.

Closes #1286 