### PR TITLE
Updating Google Deskbar Link

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -531,7 +531,7 @@
     "dateClose": "2006-05-08",
     "dateOpen": "2003-11-10",
     "description": "Google Deskbar was a small inset window on the Windows toolbar and allowed users to perform searches without leaving the desktop.",
-    "link": "https://www.computerweekly.com/news/2240053391/Google-launches-Deskbar-software",
+    "link": "https://web.archive.org/web/20210225060348/https://www.computerweekly.com/news/2240053391/Google-launches-Deskbar-software",
     "name": "Google Deskbar",
     "type": "service"
   },


### PR DESCRIPTION
The link is now dead and need to be changed to a web archive link to view the article it linked it originally.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
