### PR TITLE
Add Google Wifi app to graveyard

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2021-05-01",
+    "dateOpen": "2015-08-30",
+    "description": "Google Wifi was an app for configuring settings on Google Wifi routers.",
+    "link": "https://www.theverge.com/2021/4/2/22364381/google-wifi-router-management-home-app-discontinued",
+    "name": "Google Wifi app",
+    "type": "app"
+  },
+  {
     "dateClose": "2022-11-01",
     "dateOpen": "2012-03-29",
     "description": "Google Surveys was a business product by Google aimed at facilitating customized market research.",


### PR DESCRIPTION
Adds the Google Wifi app to the graveyard.

Closure Page: https://support.google.com/googlenest/answer/10187786?hl=en

The app's close date was found on [Apptopia](https://apptopia.com/ios/app/995373885/about) and verified based on the copyright date on [an archived version of the App Store page](https://web.archive.org/web/20190819180734/https://apps.apple.com/us/app/google-wifi/id995373885). Strangely the app seems to have been released over a year before the first Google Wifi router was released.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
