### PR TITLE
Use non-Wikipedia source for Google Toolbar

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -107,7 +107,7 @@
     "dateClose": "2021-12-11",
     "dateOpen": "2000-12-11",
     "description": "Google Toolbar was a web browser toolbar that provided a search box in web browsers like Internet Explorer and Firefox.",
-    "link": "https://en.wikipedia.org/wiki/Google_Toolbar",
+    "link": "https://arstechnica.com/gadgets/2021/12/happy-21st-birthday-to-google-toolbar-which-inexplicably-still-exists/",
     "name": "Google Toolbar",
     "type": "service"
   },


### PR DESCRIPTION
Replace Google Toolbar URL with an Ars Technica article instead of a Wikipedia article that uses Ars Technica as a citation.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
