### PR TITLE
Fix ambiguous Google TV url

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -147,7 +147,7 @@
     "dateClose": "2021-06-15",
     "dateOpen": "2011-05-10",
     "description": "Google Play Movies & TV, originally Google TV, was an app used to view purchased and rented media and was ultimately replaced with YouTube.",
-    "link": "https://en.wikipedia.org/wiki/Google_TV",
+    "link": "https://en.wikipedia.org/wiki/Google_TV_(service)",
     "name": "Google Play Movies & TV",
     "type": "app"
   },


### PR DESCRIPTION
Wikipedia has multiple pages named Google TV. Linked directly to the Google Play Movies page.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
