### PR TITLE
Simplify YouTube 3DS description

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -386,7 +386,7 @@
   {
     "dateClose": "2019-09-03",
     "dateOpen": "2013-11-29",
-    "description": "YouTube app for Nintendo 3DS, 2DS, and New 3DS allowed users to stream YouTube videos on the portable gaming console.",
+    "description": "YouTube for Nintendo 3DS allowed users to stream YouTube videos on the portable gaming console.",
     "link": "https://9to5google.com/2019/08/26/youtube-nintendo-3ds-app-shut-down/",
     "name": "YouTube for Nintendo 3DS",
     "type": "app"


### PR DESCRIPTION
Edits description of YouTube for Nintendo 3DS. Removes "app" to improve grammar and removes mention of alternate 3DS models.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
