### PR TITLE
Add proper Google Toolbar for Firefox description

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1682,7 +1682,7 @@
   {
     "dateClose": "2009-09-01",
     "dateOpen": "2005-07-19",
-    "description": "Google Toolbar for Firefox",
+    "description": "Google Toolbar for Firefox was a version of Google Toolbar designed to run on the Firefox web browser.",
     "link": "https://en.wikipedia.org/wiki/Google_Toolbar",
     "name": "Google Toolbar for Firefox",
     "type": "service"


### PR DESCRIPTION
The entry for Google Toolbar for Firefox did not have a proper description. Before, it read:
`Killed over 13 years ago, Google Toolbar for Firefox It was about 4 years old.`

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
