### PR TITLE
Improve stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,13 +3,19 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  contents: write
+  issues: write
+  pull-request: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity.'
         days-before-stale: 89
         days-before-close: 1
+        remove-stale-when-updated: true


### PR DESCRIPTION
Updates the Stale GitHub Action to latest version (Why is it v1 when v8(!!!) is out?!) and also applies recommended permissions and also `remove-stale-when-updated: true` in an attempt to fix shitty issue handling as seen in #1342 (Issue was closed despite me posting a message to keep it "active")