### PR TITLE
Add Google Domains

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2023-09-30",
+    "dateOpen": "2014-06-13",
+    "description": "Google Domains was a domain name registrar operated by Google.",
+    "link": "https://9to5google.com/2023/06/15/google-domains-squarespace/",
+    "name": "Google Domains",
+    "type": "service"
+  },
+  {
     "dateClose": "2023-03-17",
     "dateOpen": "2014-01-01",
     "description": "Jacquard was a small tag to make it easier and more intuitive for people to interact with technology in their everyday lives, without having to constantly pull out their devices or touch screens.",
@@ -7,7 +15,6 @@
     "name": "Jacquard",
     "type": "hardware"
   },
-
   {
     "dateClose": "2022-11-01",
     "dateOpen": "2012-03-29",


### PR DESCRIPTION
https://9to5google.com/2023/06/15/google-domains-squarespace/
https://newsroom.squarespace.com/blog/googledomains