### PR TITLE
Add Google Album Archive

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2,7 +2,7 @@
     {
     "dateClose": "2023-07-19",
     "dateOpen": "2016-08-05",
-    "description": "Google Album Archive was a service where photos from Google products like Hangouts would be stored.",
+    "description": "Google Album Archive was a platform that allowed users to access and manage their archived photos and videos from various Google services, such as Hangouts and Picasa Web Albums.",
     "link": "https://cordcuttersnews.com/google-is-shutting-down-album-archive/",
     "name": "Google Album Archive",
     "type": "service"

--- a/graveyard.json
+++ b/graveyard.json
@@ -1,4 +1,12 @@
 [
+    {
+    "dateClose": "2023-07-19",
+    "dateOpen": "2016-08-05",
+    "description": "Google Album Archive was a service where photos from Google products like Hangouts would be stored.",
+    "link": "https://cordcuttersnews.com/google-is-shutting-down-album-archive/",
+    "name": "Google Album Archive",
+    "type": "service"
+  },
   {
     "dateClose": "2023-09-30",
     "dateOpen": "2014-06-13",


### PR DESCRIPTION
The open date is from https://www.androidpolice.com/2016/08/01/psa-google-album-archive-shows-photo-albums-one-place/
> [According to Google's Luke Wroblewski](https://plus.google.com/+LukeWroblewski/posts/TonQQqMqvAj), Album Archive finished rolling out to everyone on August 5
