### PR TITLE
Add Firebase dynamic links

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "dateClose": "2024-11-01",
+    "dateOpen": "2016-06-10",
+    "description": "Firebase Dynamic Links was a service which allowed creating links which could behave as iOS links, Android App links, or browser links",
+    "link": "https://firebase.google.com/support/dynamic-links-faq",
+    "name": "Firebase Dynamic Links",
+    "type": "service"
+  },
+  {
     "dateClose": "2023-06-26",
     "dateOpen": "2017-11-29",
     "description": "YouTube Stories (originally YouTube Reels) allowed creators to post temporary videos that would expire after seven days.",

--- a/graveyard.json
+++ b/graveyard.json
@@ -1,6 +1,6 @@
 [
   {
-    "dateClose": "2024-11-01",
+    "dateClose": "2025-08-25",
     "dateOpen": "2016-06-10",
     "description": "Firebase Dynamic Links was a service which allowed creating links which could behave as iOS links, Android App links, or browser links.",
     "link": "https://firebase.google.com/support/dynamic-links-faq",

--- a/graveyard.json
+++ b/graveyard.json
@@ -2,7 +2,7 @@
   {
     "dateClose": "2024-11-01",
     "dateOpen": "2016-06-10",
-    "description": "Firebase Dynamic Links was a service which allowed creating links which could behave as iOS links, Android App links, or browser links",
+    "description": "Firebase Dynamic Links was a service which allowed creating links which could behave as iOS links, Android App links, or browser links.",
     "link": "https://firebase.google.com/support/dynamic-links-faq",
     "name": "Firebase Dynamic Links",
     "type": "service"


### PR DESCRIPTION
Linked to the official deprecation announcement at https://firebase.google.com/support/dynamic-links-faq, but there's also a post at https://newsletter.pragmaticengineer.com/p/google-shutting-down-firebase-dynamic which might be longer lived.

Let me know if you'd like an update to the latter.