### PR TITLE
Add Google Podcasts

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2286,8 +2286,8 @@
     "link": "https://9to5google.com/2022/11/01/google-street-view-app-shutting-down/",
     "description": "Google Street View app was an Android and iOS app that enabled people to get a 360 degree view of locations around the world.",
     "type": "app"
-   },
-   {
+  },
+  {
     "name": "Google Optimize",
     "dateOpen": "2012-06-01",
     "dateClose": "2023-09-30",
@@ -2301,6 +2301,14 @@
     "dateClose": "2023-06-15",
     "link": "https://www.androidpolice.com/google-grasshopper-code-learning-shut-down-date-revealed/",
     "description": "Grasshopper was a free mobile and web app for aspiring programmers that taught introductory JavaScript and coding fundamentals using fun, bite-sized puzzles.",
+    "type": "app"
+  },
+  {
+    "name": "Google Podcasts",
+    "dateOpen": "2018-06-18",
+    "dateClose": "2024-12-31",
+    "link": "https://www.theverge.com/2023/9/26/23890694/google-podcasts-2024-shutdown-youtube-music",
+    "description": "Google Podcasts was a podcast application.",
     "type": "app"
   }
 ]


### PR DESCRIPTION
<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->

Google Podcasts is now shutting down in favor of podcasts on YouTube Music. It only says towards end of 2024 so added end date as 2024/12/31.
