### PR TITLE
Add Buy On Google to `graveyard.json`

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2342,5 +2342,13 @@
     "link": "https://9to5google.com/2023/09/28/google-jamboard/",
     "description": "Google Jamboard was a web and native whiteboard app that offered a rich collaborative experience.",
     "type": "app"
+  },
+  {
+    "name": "Buy On Google",
+    "dateOpen": "2018-10-03",
+    "dateClose": "2023-09-26",
+    "link": "https://web.archive.org/web/20240229162408/https://support.google.com/merchants/answer/13644745",
+    "description": "Buy On Google was part of Google Shopping and allowed customers to buy products and checkout directly on Google.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Adds Buy On Google to the graveyard.

Link to earliest article of Buy On Google announcement I could find:
https://feedonomics.com/blog/what-is-buy-on-google/

Lots of articles for shutdown of the program, official article:
https://support.google.com/merchants/answer/13644745

Used Wayback Machine to save the support link to ensure the page live forever.


Tests:
```
(base) ➜  killedbygoogle git:(ssyed/bog) ✗ yarn test
yarn run v1.22.21
$ jest graveyard.test.ts
 PASS  ./graveyard.test.ts
  graveyard.json
    ✓ All values are complete (50 ms)
    ✓ Only allowed categories (8 ms)
    ✓ Unique product names (2 ms)
    Dates
      ✓ Formatted correctly (yyyy-mm-dd) (61 ms)
      ✓ Dates are valid (27 ms)
      ✓ `dateClose` is after `dateOpen` (15 ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.462 s, estimated 1 s
Ran all test suites matching /graveyard.test.ts/i.
✨  Done in 1.40s.
```