### PR TITLE
Add People Cards to graveyard.json

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2342,5 +2342,13 @@
     "link": "https://9to5google.com/2023/09/28/google-jamboard/",
     "description": "Google Jamboard was a web and native whiteboard app that offered a rich collaborative experience.",
     "type": "app"
+  },
+  {
+    "name": "People Cards",
+    "dateOpen": "2020-08-11",
+    "dateClose": "2024-04-07",
+    "link": "https://odishatv.in/news/technology/google-to-remove-people-cards-from-search-engine-229662",
+    "description": "People Cards was a crowdsourced knowledge base to enhance search results.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
This is based on the email I received yesterday:

![image](https://github.com/codyogden/killedbygoogle/assets/48585950/b57449f0-db7b-4256-b333-3c9763087483)


I could find only one news site covering this as of now. Other sites should catch up soon.

https://odishatv.in/news/technology/google-to-remove-people-cards-from-search-engine-229662

Date open is taken from the publishing date of the blog post by google - https://blog.google/intl/en-in/products/explore-communicate/introducing-people-cards-virtual/

Date close is taken from the email I received.