### PR TITLE
Add Order With Google

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2342,5 +2342,13 @@
     "link": "https://9to5google.com/2023/09/28/google-jamboard/",
     "description": "Google Jamboard was a web and native whiteboard app that offered a rich collaborative experience.",
     "type": "app"
+  },
+  {
+    "name": "Order With Google",
+    "dateOpen": "2019-05-23",
+    "dateClose": "2024-06-30",
+    "link": "https://www.restaurantbusinessonline.com/technology/google-scale-back-its-restaurant-ordering-feature",
+    "description": "Order With Google End-to-End allowed users to order food directly from Google Maps and Google Search without the need to install food delivery services' apps.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Google Maps and Search users will no longer be able to order food directly through Google, instead, they'll be redirected to a food delivery provider's website.

This is based on some emails that I've received last month from Google as I'm working directly with this service.

Here's an example restaurant (requires a VPN if you're not from North American or the UK):
 - https://food.google.com/chooseprovider?restaurantId=/g/11bbyf1938
 
![image](https://github.com/codyogden/killedbygoogle/assets/9194446/ab67ed6d-25c1-4da9-8d63-71ba70ab8507)

### News:
- https://www.restaurantbusinessonline.com/technology/google-scale-back-its-restaurant-ordering-feature
- https://www.linkedin.com/pulse/new-changes-coming-order-google-button-what-restaurants-need-hluwc

### Google Documentation:
- https://developers.google.com/actions-center/verticals/ordering/e2e/transitioning-to-redirect/overview-and-timelines