### PR TITLE
add Question Hub shut down

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2350,5 +2350,13 @@
     "link": "https://www.androidpolice.com/google-keen-shutdown-area-120-experiment/",
     "description": "Keen was a Pinterest-style platform with ML recommendations.",
     "type": "app"
+  },
+  {
+    "name": "Question Hub",
+    "dateOpen": "2019-08-08",
+    "dateClose": "2023-01-05",
+    "link": "https://searchengineland.com/google-question-hub-to-close-down-390375",
+    "description": "Question Hub was a service that identified unanswered user queries on Google and offered them to content creators to inspire targeted, informative content that fills existing content gaps on the web.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Added Question Hub shut down. Question Hub was a web service that helped lots of content creators create better content for the web.

https://en.wikipedia.org/wiki/Google_Question_Hub


I followed Contributing Guide to create this.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
