### PR TITLE
/bin/kill: respect user confirmation

### DIFF
--- a/bin/kill
+++ b/bin/kill
@@ -115,6 +115,11 @@ const isValidDate = async (value, dateOpen = false) => {
 
     const isConfirmed = await confirm.run();
 
+    if (!isConfirmed) {
+        console.log(`Nothing was changed!`);
+        return;
+    }
+
     graveyardData.push(product);
 
     fs.writeFileSync(graveyardFilePath, `${JSON.stringify(graveyardData, null, 2)}\n`);


### PR DESCRIPTION
Updates the `yarn kill` command to respect the user's confirmation and only update the graveyard if the user confirms that.