### PR TITLE
Update Jamboard app and hardware expiry date and links

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2339,15 +2339,15 @@
     "name": "Jamboard",
     "dateOpen": "2017-05-23",
     "dateClose": "2024-09-30",
-    "link": "https://9to5google.com/2023/09/28/google-jamboard/",
+    "link": "https://support.google.com/a/answer/13342662",
     "description": "Jamboard was a digital 4K touchscreen whiteboard device that allowed to collaborate using Google Workspace services.",
     "type": "hardware"
   },
   {
     "name": "Google Jamboard",
     "dateOpen": "2016-10-25",
-    "dateClose": "2024-12-31",
-    "link": "https://9to5google.com/2023/09/28/google-jamboard/",
+    "dateClose": "2024-10-01",
+    "link": "https://support.google.com/jamboard/answer/14084927",
     "description": "Google Jamboard was a web and native whiteboard app that offered a rich collaborative experience.",
     "type": "app"
   },


### PR DESCRIPTION
Updated links to lead to Google Help articles containing the dates, which may or may not be desirable as the 9to5google.com links are more user-friendly.

Also updated the end date of the app to be October 1st as even though the app will only be completely shut down on December 31st, it will switch into read-only mode on October 1st, which in my view is already "dead" as you can't use it to create any new content. The only reason it is still accessible from that point is to migrate your creations off-platform before access is removed entirely, which I do not consider to be "useable" any more.

Fixes #1530