### PR TITLE
Added ClassyShark to graveyard

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "ClassyShark",
+    "dateOpen": "2015-11-03",
+    "dateClose": "2024-07-22",
+    "link": "https://github.com/google/android-classyshark",
+    "description": "ClassyShark was a standalone binary inspection tool for Android developers.",
+    "type": "app"
+  },
+  {
     "name": "Chromecast",
     "dateOpen": "2013-07-24",
     "dateClose": "2024-08-06",


### PR DESCRIPTION
Timeline:

- 2015, October: [First commit](https://github.com/google/android-classyshark/commit/581c42114d59ea5a3ce74b2116651850a88c10a6)
- 2015, November: [First release](https://github.com/google/android-classyshark/releases/tag/1-android-drop) (I set `dateOpen` to this one)
- 2015, December: [First mention on StackOverflow](https://stackoverflow.com/revisions/23924665/2)
- 2016, April: Twitter account created, only ever made one post (a release announcement, [view without X account](https://xcancel.com/ItsClassyshark))
- 2016, June: Disclaimer "not an official Google product" gets [removed from the readme](https://github.com/google/android-classyshark/commit/47d79039efa40f62a1bd90c0bc33471cd4eb5b4c)
- 2018, July: [Last release](https://github.com/google/android-classyshark/releases/tag/8.2)
- 2018, December: A StackOverflow user [says](https://stackoverflow.com/questions/4191762/how-to-view-androidmanifest-xml-from-apk-file/4191807#comment94022156_40686067) ClassyShark is much easier to use than existing tools, 7 people agree. Sadly, the project was already being abandoned at this time
- 2020, July: Domain expired, turned into a porn side ([#188](https://github.com/google/android-classyshark/pull/188)). Twitter account still links there, but the [twitter link is removed from the readme](https://github.com/google/android-classyshark/commit/9c61d6df79c971a0b6c83795e7a91f2a375585cf) instead (perhaps they do not have the login anymore?)
- 2023, May: [Last commit (merging a bugfix)](https://github.com/google/android-classyshark/commit/78ddba71b0d869cc6283f8cdbb2061b6e57a3781)
- 2024, July: [Repository archived by owner](https://github.com/google/android-classyshark)
