### PR TITLE
Add Network Planner

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2366,5 +2366,13 @@
     "link": "https://www.androidpolice.com/google-keen-shutdown-area-120-experiment/",
     "description": "Keen was a Pinterest-style platform with ML recommendations.",
     "type": "app"
+  },
+  {
+    "name": "Network Planner",
+    "dateOpen": "2019-03-20",
+    "dateClose": "2025-01-31",
+    "link": "https://www.lightreading.com/network-automation/google-to-retire-cbrs-network-planning-tool",
+    "description": "Network Planner was a CBRS network and spectrum planning service.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
Not 100% sure on the launch date, but this service is obscure enough that there was barely any coverage.