### PR TITLE
Add Google Search to the graveyard (1998–2024)

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2366,5 +2366,13 @@
     "link": "https://www.androidpolice.com/google-keen-shutdown-area-120-experiment/",
     "description": "Keen was a Pinterest-style platform with ML recommendations.",
     "type": "app"
+  },
+  {
+    "name": "Google Search",
+    "dateOpen": "1998-09-15",
+    "dateClose": "2024-10-14",
+    "link": "https://search.google/ways-to-search/ai-overviews/",
+    "description": "Google Search was the world's most popular search engine, designed to connect users to information across the web. In 2024, it was effectively killed when AI Overviews replaced traditional search results, scraping content from websites without clicks or credit, and turning a once-powerful discovery engine into an ad-serving hallucination machine.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Google Search, once the crown jewel of the internet, has been effectively killed by its own AI Overviews feature.

Rather than directing users to real websites, Search now serves auto-generated answers scraped from across the web—without traffic, credit, or context. This change has gutted the open web, destroyed publisher revenue, and turned the world’s best discovery tool into a hallucination-prone content sponge.

It’s not dead because it’s offline.
It’s dead because it betrayed its purpose.

🪦 RIP Google Search (1998–2024)