### PR TITLE
Add Tables by Area 120, to be discontinued 2025-12-16

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2374,5 +2374,13 @@
     "link": "https://www.androidpolice.com/google-keen-shutdown-area-120-experiment/",
     "description": "Keen was a Pinterest-style platform with ML recommendations.",
     "type": "app"
+  },
+  {
+    "name": "Tables by A120",
+    "dateOpen": "2020-03-05",
+    "dateClose": "2025-12-16",
+    "link": "https://en.wikipedia.org/wiki/Tables_(Google)",
+    "description": "Tables was a collaborative database platform and competitor to Airtable, focused on making project tracking more efficient with automation.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Found out [via Techcrunch](https://techcrunch.com/2025/09/11/google-is-shutting-down-tables-its-airtable-rival/) earlier today. Google's FAQ is [here](https://support.google.com/area120-tables/answer/10831919).

The FAQ is also linked from the warning banner at Tables' homepage:

<img width="1735" height="1389" alt="image" src="https://github.com/user-attachments/assets/f717ace5-f5b5-4b0d-9efa-ab80ab2718c7" />

I guess #1595 was prescient.