### PR TITLE
Fix the description of Google Toolbar for Firefox

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1738,7 +1738,7 @@
   {
     "dateClose": "2009-09-01",
     "dateOpen": "2005-07-19",
-    "description": "Google Toolbar for Firefox",
+    "description": "Google Toolbar was a web browser toolbar that provided a search box in web browsers like Internet Explorer and Firefox.",
     "link": "https://en.wikipedia.org/wiki/Google_Toolbar",
     "name": "Google Toolbar for Firefox",
     "type": "service"


### PR DESCRIPTION
<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->

I'm reusing the description of Google Toolbar since Google Toolbar for Firefox refers to the same service.