### PR TITLE
Kill Dark Web Report

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "Dark Web Report",
+    "dateOpen": "2023-03-08",
+    "dateClose": "2026-01-15",
+    "link": "https://support.google.com/websearch/answer/16767242",
+    "description": "A service that monitored the dark web for personal information and notified users if their data was found in data breaches.",
+    "type": "service"
+  },
+  {
     "name": "Chromecast",
     "dateOpen": "2013-07-24",
     "dateClose": "2024-08-06",


### PR DESCRIPTION
Discontinued via email notification. More info at https://support.google.com/websearch/answer/16767242. Monitoring stops Jan 15, 2026.

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
