### PR TITLE
added delve

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2390,5 +2390,13 @@
     "link": "https://support.google.com/websearch/answer/16767242",
     "description": "Dark Web Reports was a dark web scanner that searched for personal info leaks.",
     "type": "service"
+  },
+  {
+    "name": "Delve",
+    "dateOpen": "2020-10-13",
+    "dateClose": "2026-05-04",
+    "link": "https://www.archdaily.com/949392/sidewalk-labs-reimagines-urban-planning-with-new-delve-generative-design-tool",
+    "description": "Delve was a tool to help developers, architects and urban designers discover optimal design choices for neighborhood projects.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Added Delve by Sidewalklabs to the graveyard.

There is not much documentation about it's closing yet unfortunately, but the sundown notice is visible on the website and was sent to every user by email (see screenshot).

Sidewalklabs was [absorbed into Google in 2022](https://www.theverge.com/2021/12/16/22840028/sidewalk-labs-google-doctoroff-health-toronto-quayside)

<img width="531" height="818" alt="image" src="https://github.com/user-attachments/assets/6202580d-5b1a-4312-ae7e-2115f5939a2c" />
