### PR TITLE
Add Socratic

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2393,7 +2393,7 @@
   },
   {
     "name": "Socratic",
-    "dateOpen": "2019-08-15",
+    "dateOpen": "2013-08-15",
     "dateClose": "2024-08-31",
     "link": "https://en.wikipedia.org/wiki/Socratic_(Google)",
     "description": "Socratic was a free educational app that helped students with homework by scanning questions with a smartphone camera and offering step-by-step solutions.",

--- a/graveyard.json
+++ b/graveyard.json
@@ -2390,5 +2390,13 @@
     "link": "https://support.google.com/websearch/answer/16767242",
     "description": "Dark Web Reports was a dark web scanner that searched for personal info leaks.",
     "type": "service"
+  },
+  {
+    "name": "Socratic",
+    "dateOpen": "2019-08-15",
+    "dateClose": "2024-08-31",
+    "link": "https://en.wikipedia.org/wiki/Socratic_(Google)",
+    "description": "Socratic was a free educational app that helped students with homework by scanning questions with a smartphone camera and offering step-by-step solutions.",
+    "type": "app"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds Socratic, the Google educational homework-help app, to `graveyard.json`.
- Launched 2019-08-15, discontinued 2024-08-31; merged into Google Lens.

Closes #1652

## Test plan
- [ ] `yarn test` passes (graveyard.json schema/date/uniqueness checks)

https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS)_