### PR TITLE
Add YouTube for Wii

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2422,5 +2422,13 @@
     "link": "https://www.pcmag.com/news/rip-google-glass-enterprise-as-sales-for-smart-glasses-end",
     "description": "Glass Enterprise Edition was a head-up display for enterprise customers.",
     "type": "hardware"
+  },
+  {
+    "name": "YouTube for Wii",
+    "dateOpen": "2012-11-15",
+    "dateClose": "2022-10-27",
+    "link": "https://en.wikipedia.org/wiki/YouTube_TV_app#Nintendo_Wii",
+    "description": "YouTube for Nintendo Wii was an app that let Wii and Wii U users stream YouTube videos on their TVs.",
+    "type": "app"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds YouTube for Wii (2012-11-15 → 2022-10-27) to `graveyard.json` as an app entry covering the Wii and Wii U YouTube clients.

Closes #1636
Closes #1637

## Test plan
- [ ] `yarn test` passes (graveyard.json schema/date/uniqueness checks)

https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS)_