### PR TITLE
Add Steam for Chromebooks

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2430,5 +2430,13 @@
     "link": "https://en.wikipedia.org/wiki/YouTube_TV_app#Nintendo_Wii",
     "description": "YouTube for Nintendo Wii was an app that let Wii and Wii U users stream YouTube videos on their TVs.",
     "type": "app"
+  },
+  {
+    "name": "Steam for Chromebooks",
+    "dateOpen": "2022-11-01",
+    "dateClose": "2026-01-01",
+    "link": "https://9to5google.com/2025/08/07/steam-chromebook-2026/",
+    "description": "Steam for Chromebooks is an beta initiative that allowed users to install and run PC games via the Steam client.",
+    "type": "app"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds Steam for Chromebooks (2022-11-01 → 2026-01-01) to `graveyard.json` as an app entry, sourced from the 9to5google discontinuation report.

Closes #1640

## Test plan
- [ ] `yarn test` passes (graveyard.json schema/date/uniqueness checks)

https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS)_