### PR TITLE
Remove Analytics link, re-add Twitter in footer

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -77,10 +77,6 @@ const Footer = () => (
                     <a href="https://github.com/codyogden/killedbygoogle/blob/main/LICENSE">
                         &copy; {(new Date()).getFullYear()} Cody Ogden.
           </a>
-          &nbsp;-&nbsp;
-          <a href="https://analytics.kbg.rip" target="_blank" rel="noopener noreferrer">
-                        Analytics
-          </a>
                 </div>
                 <div className={styles.socialWrapper}>
                     <SocialLink

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -80,6 +80,11 @@ const Footer = () => (
                 </div>
                 <div className={styles.socialWrapper}>
                     <SocialLink
+                        url="https://x.com/killedbygoogle"
+                        altText="Twitter"
+                        imgSrc='https://static.killedbygoogle.com/com/twitter.svg'
+                    />
+                    <SocialLink
                         url="https://killedbygoogle.blue"
                         altText="BlueSky"
                         imgSrc='https://static.killedbygoogle.com/com/bsky.svg'


### PR DESCRIPTION
## Summary
- Removes the `Analytics` link (and its separator) from the footer.
- Re-adds the Twitter (`x.com/killedbygoogle`) social link before the BlueSky link.

## Test plan
- [ ] Footer renders without the Analytics link
- [ ] Twitter icon appears before BlueSky in the social row and links to `https://x.com/killedbygoogle`

https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS)_