### PR TITLE
Jamboard updates.

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2348,7 +2348,7 @@
     "dateOpen": "2016-10-25",
     "dateClose": "2024-10-01",
     "link": "https://9to5google.com/2023/09/28/google-jamboard/",
-    "description": "Google Jamboard was a web and native whiteboard app that offered a rich collaborative experience.",
+    "description": "Google Jamboard was a web app, native whiteboard app, and standalone whiteboard hardware that offered a collaborative experience.",
     "type": "app"
   },
   {

--- a/graveyard.json
+++ b/graveyard.json
@@ -2354,7 +2354,7 @@
   {
     "name": "Google Jamboard",
     "dateOpen": "2016-10-25",
-    "dateClose": "2024-12-31",
+    "dateClose": "2024-10-01",
     "link": "https://9to5google.com/2023/09/28/google-jamboard/",
     "description": "Google Jamboard was a web and native whiteboard app that offered a rich collaborative experience.",
     "type": "app"

--- a/graveyard.json
+++ b/graveyard.json
@@ -2344,14 +2344,6 @@
     "type": "app"
   },
   {
-    "name": "Jamboard",
-    "dateOpen": "2017-05-23",
-    "dateClose": "2024-09-30",
-    "link": "https://9to5google.com/2023/09/28/google-jamboard/",
-    "description": "Jamboard was a digital 4K touchscreen whiteboard device that allowed to collaborate using Google Workspace services.",
-    "type": "hardware"
-  },
-  {
     "name": "Google Jamboard",
     "dateOpen": "2016-10-25",
     "dateClose": "2024-10-01",


### PR DESCRIPTION
## Summary
- Updates the Google Jamboard `dateClose` from `2024-12-31` to `2024-10-01`.
- Removes the duplicate `Jamboard` hardware entry.

Supersedes and closes #1539.

## Test plan
- [ ] `yarn test` passes (graveyard.json schema/date/uniqueness checks)

https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS