### PR TITLE
Bump LICENSE copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Cody Ogden
+Copyright (c) 2026 Cody Ogden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Bumps the LICENSE copyright year from 2024 to 2026.

https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrvHTBq1VVbFVx2NaM5sQS)_