### PR TITLE
Add top margin to PressCoverage component

### DIFF
--- a/components/PressCoverage.tsx
+++ b/components/PressCoverage.tsx
@@ -48,7 +48,7 @@ const links = [
 ];
 
 const PressCoverage = () => (
-  <div className="bg-muted py-10">
+  <div className="bg-muted mt-10 py-10">
     <h4 className="m-0 text-center text-[1.25em] font-normal uppercase">As seen on</h4>
     <ul className="mx-auto flex w-[1000px] max-w-[80%] list-none flex-row flex-wrap items-center justify-center p-0">
       {links.map((link) => (


### PR DESCRIPTION
## Description
Added `mt-10` (margin-top) class to the PressCoverage component's root div element to improve spacing between this section and the content above it.

## Changes
- Modified `components/PressCoverage.tsx`: Added `mt-10` utility class to the container div

## Test Plan
N/A - This is a styling adjustment. Visual verification in the browser will confirm proper spacing.

https://claude.ai/code/session_019ZQ6FRgMLKDqwcc7MGFiye