### PR TITLE
Make filter dropdown span full width on mobile

### DIFF
--- a/components/Filter.tsx
+++ b/components/Filter.tsx
@@ -35,7 +35,7 @@ const Filter: React.FC<Props> = ({ items, filterHandler }) => {
         defaultValue={FilterType.ALL}
         onChange={(event) => filterHandler(event.target.value as FilterType)}
         style={CHEVRON_BG}
-        className="block min-w-[200px] cursor-pointer appearance-none rounded border border-input bg-popover bg-no-repeat px-3 py-2 pr-8 font-[inherit] text-sm text-foreground hover:border-input-hover focus:border-ring focus:ring-2 focus:ring-ring/25 focus:outline-none"
+        className="block w-full min-w-[200px] cursor-pointer appearance-none rounded border border-input bg-popover bg-no-repeat px-3 py-2 pr-8 font-[inherit] text-sm text-foreground hover:border-input-hover focus:border-ring focus:ring-2 focus:ring-ring/25 focus:outline-none"
       >
         <option value={FilterType.ALL}>All ({items.length})</option>
         <option value={FilterType.APP}>Apps ({counts.app})</option>


### PR DESCRIPTION
## Summary
- The filter `<select>` only had `min-w-[200px]`, so on iOS Safari (and other viewports <=700px where the Controls grid collapses to a single column) it sat at 200px while the search input filled the row, leaving empty space to its right.
- Adding `w-full` makes the dropdown fill its grid cell on mobile so it matches the search input's width.
- On desktop the Controls column is fixed at `200px`, so behavior there is unchanged.

## Test plan
- [ ] Verify on iOS Safari (or a narrow viewport <=700px) that the filter dropdown spans the full width of the search input.
- [ ] Verify desktop (>700px) layout is unchanged: search on the left, 200px filter on the right.

https://claude.ai/code/session_019ZQ6FRgMLKDqwcc7MGFiye