### PR TITLE
Add Perspective API

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2438,5 +2438,13 @@
     "link": "https://en.wikipedia.org/wiki/YouTube_TV_app#Nintendo_Wii",
     "description": "YouTube for Nintendo Wii was an app that let Wii and Wii U users stream YouTube videos on their TVs.",
     "type": "app"
+  },
+  {
+    "name": "Perspective API",
+    "dateOpen": "2017-02-23",
+    "dateClose": "2027-01-01",
+    "link": "https://en.wikipedia.org/wiki/Jigsaw_(company)#Perspective",
+    "description": "Perspective API was a tool for web publishers to identify toxic comments.",
+    "type": "service"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "date-fns": "^4.1.0",
     "enquirer": "^2.4.1",
     "lucide-react": "^1.14.0",
-    "moment": "^2.30.1",
     "next": "16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "date-fns": "^4.1.0",
     "enquirer": "^2.4.1",
     "lucide-react": "^1.14.0",
+    "moment": "^2.30.1",
     "next": "16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",


### PR DESCRIPTION
Adds the Perspective API which was a Jigsaw/Google API ending at the end of 2026.

Refresh of #1631

- Updated link to Wikipedia instead of Archive.org
- Updated description to use the official flavor text.
- Ensured all test passed and the PR was so fresh and so clean clean.
