### PR TITLE
Fix a typo and change tense for Steam for Chromebooks text

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2428,7 +2428,7 @@
     "dateOpen": "2022-11-01",
     "dateClose": "2026-01-01",
     "link": "https://9to5google.com/2025/08/07/steam-chromebook-2026/",
-    "description": "Steam for Chromebooks is an beta initiative that allowed users to install and run PC games via the Steam client.",
+    "description": "Steam for Chromebooks was a beta initiative that allowed users to install and run PC games via the Steam client.",
     "type": "app"
   },
   {


### PR DESCRIPTION
Just a small fix to the description for Steam for Chromebooks.