### PR TITLE
feat(graveyard): add Project Mariner

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "Project Mariner",
+    "dateOpen": "2024-12-11",
+    "dateClose": "2026-05-04",
+    "link": "https://en.wikipedia.org/wiki/Project_Mariner",
+    "description": "Project Mariner was a research prototype AI agent by Google DeepMind that could browse the web on a user's behalf to perform tasks like online shopping, information retrieval, and form-filling.",
+    "type": "service"
+  },
+  {
     "name": "Chromecast",
     "dateOpen": "2013-07-24",
     "dateClose": "2024-08-06",


### PR DESCRIPTION
## Add Project Mariner to the graveyard

Project Mariner — Google DeepMind's research-prototype web-browsing AI agent — was discontinued on **May 4, 2026**. It's not currently in `graveyard.json`, so this PR adds it.

### Entry

| Field | Value |
|---|---|
| `name` | Project Mariner |
| `dateOpen` | 2024-12-11 (initial release as a research prototype) |
| `dateClose` | 2026-05-04 |
| `type` | service |
| `link` | https://en.wikipedia.org/wiki/Project_Mariner |

### Description

> Project Mariner was a research prototype AI agent by Google DeepMind that could browse the web on a user's behalf to perform tasks like online shopping, information retrieval, and form-filling.

### Sources

- **Wikipedia — Project Mariner:** https://en.wikipedia.org/wiki/Project_Mariner
  - Confirms launch (Dec 11, 2024) and discontinuation (May 4, 2026); categorized under *Discontinued Google services*.
- **Original announcement / labs page (Google-hosted, may be removed):** https://labs.google.com/mariner/landing
- **DeepMind product page (Google-hosted, may be removed):** https://deepmind.google/models/project-mariner/
- **Coverage of the 2025 rollout (context):**
  - TechCrunch — "Google rolls out Project Mariner, its web-browsing AI agent" (May 20, 2025)
  - The Verge — "Google is bringing an 'Agent Mode' to the Gemini app" (May 20, 2025)

Per the contributing guide I avoided linking to Google-owned URLs as the primary source since those tend to disappear shortly after a product is killed; Wikipedia is used instead.

### Checklist

- [x] Entry follows the schema (name / dateOpen / dateClose / link / description / type)
- [x] `type` is one of `app` / `service` / `hardware` (chose `service` — it was a cloud-hosted AI agent; the Chrome extension was just the delivery surface)
- [x] Description is a single past-tense sentence beginning with the product name
- [x] Link is not a Google-owned URL
- [x] Dates are valid `yyyy-mm-dd`, `dateClose` is after `dateOpen`
- [x] Name is unique (no existing "Mariner" entry)
