### PR TITLE
Add "Be Internet Awesome World (Roblox)"

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2438,5 +2438,13 @@
     "link": "https://en.wikipedia.org/wiki/YouTube_TV_app#Nintendo_Wii",
     "description": "YouTube for Nintendo Wii was an app that let Wii and Wii U users stream YouTube videos on their TVs.",
     "type": "app"
+  },
+  {
+    "name": "Be Internet Awesome World (Roblox)",
+    "dateOpen": "2024-09-25",
+    "dateClose": "2026-06-20",
+    "link": "https://www.roblox.com/games/17756790122/Google-Be-Internet-Awesome-World",
+    "description": "Be Internet Awesome World was an experience on Roblox that teached kids how to be safe on the internet.",
+    "type": "app"
   }
 ]


### PR DESCRIPTION
This adds the entry for Google's Roblox experience called "Google Be Internet Awesome World," which, according to the game description, will shut down on the 20th of June this year.

https://www.roblox.com/games/17756790122/Google-Be-Internet-Awesome-World
https://blog.google/innovation-and-ai/technology/safety-security/be-internet-awesome-roblox/

Honestly, this is one of the weirder things Google decided to shut down. Especially because Roblox games don't really need to be shut down; you can keep them public with no real problems/costs. Like, they could still earn Robux (the digital currency) by having people join the game and turn their earnings into real-world money! Like, uuugh...

Maybe it was trademark licensing issues, who knows? Only Google knows.
