### PR TITLE
Add Spectrum Access System (SAS) to the graveyard

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2446,5 +2446,13 @@
     "link": "https://9to5google.com/2026/06/05/google-shuts-down-pixel-studio-with-the-latest-app-update/",
     "description": "Pixel Studio allowed users to quickly generate AI images using a prompt and provided a library of past generative images.",
     "type": "app"
+  },
+  {
+    "name": "Spectrum Access System",
+    "dateOpen": "2020-01-27",
+    "dateClose": "2027-06-10",
+    "link": "https://www.fierce-network.com/wireless/google-exits-cbrs-sas-administration-business",
+    "description": "Spectrum Access System (SAS) was a cloud-based platform that managed and coordinated shared access to Citizens Broadband Radio Service (CBRS) spectrum in the 3.5 GHz band.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
## Summary

Adds Google's **Spectrum Access System (SAS)** to `graveyard.json`, following the same format as the existing entries.

| Field | Value |
| --- | --- |
| **Name** | Spectrum Access System |
| **dateOpen** | 2020-01-27 — the FCC certified Google as a SAS administrator, authorizing full commercial deployment in the 3.5 GHz CBRS band |
| **dateClose** | 2027-06-10 — Google is winding down its SAS offering and customers must migrate to a new SAS provider by this date |
| **Type** | service |
| **Link** | [Fierce Network: Google exits CBRS SAS administration business](https://www.fierce-network.com/wireless/google-exits-cbrs-sas-administration-business) |

### Notes
- Per the project's editorial guidelines, the link points to a news organization rather than a Google-provided URL (Google removes those quickly after a service is ended).
- This is my first contribution — happy to take any suggestions on the description, dates, or link.