### PR TITLE
Update Google Earth Pro description to past tense

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2452,7 +2452,7 @@
     "dateOpen": "2001-06-10",
     "dateClose": "2027-06-25",
     "link": "https://www.theverge.com/tech/962479/get-google-earth-pro-while-you-still-can",
-    "description": "Google Earth Pro is a desktop app that gives users access to Google Earth with more advanced features.",
+    "description": "Google Earth Pro was a desktop app that gave users access to Google Earth with more advanced features.",
     "type": "app"
   }
 ]


### PR DESCRIPTION
Updates the Google Earth Pro description in `graveyard.json` to use past tense, consistent with the tone of other entries in the graveyard.

**Before:** "Google Earth Pro is a desktop app that gives users access to Google Earth with more advanced features."

**After:** "Google Earth Pro was a desktop app that gave users access to Google Earth with more advanced features."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tox6DyUChs5D4HgLaWimyL)_