### PR TITLE
Add pring obituary

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2454,5 +2454,13 @@
     "link": "https://www.theverge.com/tech/962479/get-google-earth-pro-while-you-still-can",
     "description": "Google Earth Pro was a desktop app that gave users access to Google Earth with more advanced features.",
     "type": "app"
+  },
+  {
+    "name": "pring",
+    "dateOpen": "2018-03-08",
+    "dateClose": "2026-12-01",
+    "link": "https://www.itmedia.co.jp/news/articles/2605/22/news129.html",
+    "description": "pring was a smartphone app for peer-to-peer money transfers and cashless payments, acquired by Google in 2021.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
This pull request adds the pring obituary to the graveyard.

> pring was a smartphone app for peer-to-peer money transfers and cashless payments, acquired by Google in 2021.

Closes #1700

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
