### PR TITLE
Google Search Dictionary

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -2454,5 +2454,13 @@
     "link": "https://www.theverge.com/tech/962479/get-google-earth-pro-while-you-still-can",
     "description": "Google Earth Pro was a desktop app that gave users access to Google Earth with more advanced features.",
     "type": "app"
+  },
+  {
+    "name": "Google Search Dictionary",
+    "dateOpen": "2011-08-05",
+    "dateClose": "2026-05-20",
+    "link": "https://en.wikipedia.org/wiki/Google_Dictionary",
+    "description": "Google Dictionary was an online dictionary in a number of languages accessible through Google searches after the previous site of the same name was integrated into Search.",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
Google Dictionary has been discontinued again, somehow. The linked Wikipedia article doesn't actually provide the date which it happened but I'm certain without a doubt that it was on or around May 20, 2026, after Google I/O when they announced they would be prioritising AI Overviews over normal search and eventually aimed to remove that (#1685). See [this 9to5 article](https://9to5google.com/2026/05/22/google-ai-overview-dictionary/) describing the change as "as of late", [this Business Insider article](https://www.businessinsider.com/google-ai-overview-disregard-defining-words-2026-5) claiming it happened on Friday (21 May), [a Google Blog post which shows a gif (/ɡɪf/) of the AI Overview replacement of dictionary as the example of the expansion of AI Overview after I/O](https://blog.google/products-and-platforms/products/search/ai-overview-expansion-may-2025-update/) on May 20, etcetc. I can't put multiple links and a link to an article primarily about its replacement isn't really useful to anyone, so. One caveat is that all names have to be unique (didn't account for Google discontinuing the same thing twice I suppose) so in the name field it is "Google Search Dictionary" here.